### PR TITLE
Trailing stop loss

### DIFF
--- a/Binance Detect Moonings.py
+++ b/Binance Detect Moonings.py
@@ -252,7 +252,7 @@ def buy():
             else:
                 orders[coin] = client.get_all_orders(symbol=coin, limit=1)
 
-                # binance sometimes returns an empty list, the code will wait here unti binance returns the order
+                # binance sometimes returns an empty list, the code will wait here until binance returns the order
                 while orders[coin] == []:
                     print('Binance is being slow in returning the order, calling the API again...')
 

--- a/Binance Detect Moonings.py
+++ b/Binance Detect Moonings.py
@@ -50,18 +50,18 @@ else:
 ####################################################
 
 
-# select what to pair the coins to and pull all coins paied with PAIR_WITH
+# select what to pair the coins to and pull all coins paired with PAIR_WITH
 PAIR_WITH = 'USDT'
 
 # Define the size of each trade, by default in USDT
 QUANTITY = 100
 
-# List of pairs to exlcude
+# List of pairs to exclude
 # by default we're excluding the most popular fiat pairs
 # and some margin keywords, as we're only working on the SPOT account
 FIATS = ['EURUSDT', 'GBPUSDT', 'JPYUSDT', 'USDUSDT', 'DOWN', 'UP']
 
-# the amount of time in MINUTES to calculate the differnce from the current price
+# the amount of time in MINUTES to calculate the difference from the current price
 TIME_DIFFERENCE = 5
 
 # the difference in % between the first and second checks for the price, by default set at 10 minutes apart.
@@ -72,6 +72,14 @@ STOP_LOSS = 3
 
 # define in % when to take profit on a profitable coin
 TAKE_PROFIT = 6
+
+# whether to use trailing stop loss or not; default is True
+USE_TRAILING_STOP_LOSS = True
+
+# when hit TAKE_PROFIT, move STOP_LOSS to TRAILING_STOP_LOSS percentage points below TAKE_PROFIT hence locking in profit
+# when hit TAKE_PROFIT, move TAKE_PROFIT up by TRAILING_TAKE_PROFIT percentage points
+TRAILING_STOP_LOSS = 2
+TRAILING_TAKE_PROFIT = 2
 
 # use custom tickers.txt list for filtering pairs
 CUSTOM_LIST = False
@@ -263,22 +271,32 @@ def buy():
 
 
 def sell_coins():
-    '''sell coins that have reached the STOP LOSS or TAKE PROFIT thershold'''
+    '''sell coins that have reached the STOP LOSS or TAKE PROFIT threshold'''
 
     last_price = get_price()
     coins_sold = {}
 
     for coin in list(coins_bought):
         # define stop loss and take profit
-        TP = float(coins_bought[coin]['bought_at']) + (float(coins_bought[coin]['bought_at']) * TAKE_PROFIT) / 100
-        SL = float(coins_bought[coin]['bought_at']) - (float(coins_bought[coin]['bought_at']) * STOP_LOSS) / 100
+        TP = float(coins_bought[coin]['bought_at']) + (float(coins_bought[coin]['bought_at']) * coins_bought[coin]['take_profit']) / 100
+        SL = float(coins_bought[coin]['bought_at']) + (float(coins_bought[coin]['bought_at']) * coins_bought[coin]['stop_loss']) / 100
 
         LastPrice = float(last_price[coin]['price'])
         BuyPrice = float(coins_bought[coin]['bought_at'])
         PriceChange = float((LastPrice - BuyPrice) / BuyPrice * 100)
 
-        # check that the price is above the take profit or below the stop loss
-        if float(last_price[coin]['price']) > TP or float(last_price[coin]['price']) < SL:
+        # check that the price is above the take profit and readjust SL and TP accordingly if trialing stop loss used
+        if float(last_price[coin]['price']) > TP and USE_TRAILING_STOP_LOSS:
+            print("TP reached, adjusting TP and SL accordingly to lock-in profit")
+            
+            # increasing TP by TRAILING_TAKE_PROFIT (essentially next time to readjust SL)
+            coins_bought[coin]['take_profit'] += TRAILING_TAKE_PROFIT
+            coins_bought[coin]['stop_loss'] = coins_bought[coin]['take_profit'] - TRAILING_STOP_LOSS
+
+            continue
+
+        # check that the price is below the stop loss or above take profit (if trailing stop loss not used) and sell if this is the case 
+        if float(last_price[coin]['price']) < SL or (float(last_price[coin]['price']) > TP and not USE_TRAILING_STOP_LOSS):
             print(f"TP or SL reached, selling {coins_bought[coin]['volume']} {coin} - {BuyPrice} - {LastPrice} : {PriceChange:.2f}%")
 
             if TESTNET :
@@ -306,13 +324,15 @@ def sell_coins():
                 # Log trade
                 if LOG_TRADES:
                     write_log(f"Sell: {coins_sold[coin]['volume']} {coin} - {BuyPrice} - {LastPrice} : {PriceChange:.2f}%")
-        else:
-            print(f'TP or SL not yet reached, not selling {coin} for now {BuyPrice} - {LastPrice} : {PriceChange:.2f}% ')
+            continue
+
+        # no action
+        print(f'TP or SL not yet reached, not selling {coin} for now {BuyPrice} - {LastPrice} : {PriceChange:.2f}% ')
 
     return coins_sold
 
 
-def update_porfolio(orders, last_price, volume):
+def update_portfolio(orders, last_price, volume):
     '''add every coin bought to our portfolio for tracking/selling later'''
     print(orders)
     for coin in orders:
@@ -322,7 +342,9 @@ def update_porfolio(orders, last_price, volume):
             'orderid': orders[coin][0]['orderId'],
             'timestamp': orders[coin][0]['time'],
             'bought_at': last_price[coin]['price'],
-            'volume': volume[coin]
+            'volume': volume[coin],
+            'stop_loss': -STOP_LOSS,
+            'take_profit': TAKE_PROFIT,
             }
 
         # save the coins in a json file in the same directory
@@ -332,7 +354,7 @@ def update_porfolio(orders, last_price, volume):
         print(f'Order with id {orders[coin][0]["orderId"]} placed and saved to file')
 
 def remove_from_portfolio(coins_sold):
-    '''Remove coins sold due to SL or TP from portofio'''
+    '''Remove coins sold due to SL or TP from portfolio'''
     for coin in coins_sold:
         coins_bought.pop(coin)
 
@@ -354,6 +376,6 @@ if __name__ == '__main__':
 
     for i in count():
         orders, last_price, volume = buy()
-        update_porfolio(orders, last_price, volume)
+        update_portfolio(orders, last_price, volume)
         coins_sold = sell_coins()
         remove_from_portfolio(coins_sold)

--- a/Readme.txt
+++ b/Readme.txt
@@ -13,3 +13,8 @@ Requirements: python-binance .7.9
 
 For a step-by-step guide on how to implement and configure this bot please see the guide at: 
 https://www.cryptomaton.org/2021/05/08/how-to-code-a-binance-trading-bot-that-detects-the-most-volatile-coins-on-binance/
+
+In order to run this script in the background without demonizing, you can execute it in the following way (Linux only):
+# nohup python3 -u Binance\ Detect\ Moonings.py >> log.txt 2>&1 &
+The logs are stored in log.txt.
+To stop the process either look in your process list with `ps aux | grep -i python3` and kill with `kill PROCESS_ID` or `killall python3` when you know what you're doing.


### PR DESCRIPTION
Addresses https://github.com/CyberPunkMetalHead/Binance-volatility-trading-bot/issues/34 by adding `TRAILING_TAKE_PROFIT` and `TRAILING_STOP_LOSS` variables. The former is by how much to increase the TP once the old TP is hit; the latter is where to place the new SL (percentage points below new TP).

*NOT TESTED*, so some code review + testing on demo accounts would be appreciated

Also fixes some spelling mistakes in code.