### PR TITLE
bugfix(testnet): change the api's url when in TEST_MODE

### DIFF
--- a/Binance Detect Moonings.py
+++ b/Binance Detect Moonings.py
@@ -518,7 +518,11 @@ if __name__ == '__main__':
         client = Client(access_key, secret_key, tld='us')
     else:
         client = Client(access_key, secret_key)
-        
+
+    # Change the API URL to use testnet
+    if TEST_MODE:
+        client.API_URL = 'https://testnet.binance.vision/api'
+
     # If the users has a bad / incorrect API key.
     # this will stop the script from starting, and display a helpful error.
     api_ready, msg = test_api_key(client, BinanceAPIException)


### PR DESCRIPTION
The API URL is unchanged when turning TEST_MODE on, rendering the API keys obtained from [testnet.binance.vision/](https://testnet.binance.vision/) unusable