### PR TITLE
Mongo DB Support

### DIFF
--- a/Binance Detect Moonings.py
+++ b/Binance Detect Moonings.py
@@ -519,6 +519,8 @@ if __name__ == '__main__':
 
     # Default no debugging
     DEBUG = False
+    
+    MONGO = False
 
     # Load system vars
     TEST_MODE = parsed_config['script_options']['TEST_MODE']

--- a/Binance Detect Moonings.py
+++ b/Binance Detect Moonings.py
@@ -305,6 +305,14 @@ def buy():
                     'orderId': time.time(),
                     'time': datetime.now().timestamp()
                 }]
+                data = {
+                    "volume": volume[coin],
+                    "timestamp": time.time(),
+                    "action": "buy",
+                    "coin": coin,
+                    "lastPrice": last_price[coin]['price']
+                }
+                if MONGO: insert_trades(data, DATABASE_NAME)
 
                 # Log trade
                 if LOG_TRADES:
@@ -320,6 +328,8 @@ def buy():
                     type = 'MARKET',
                     quantity = volume[coin]
                 )
+
+
                 
 
             # error handling here in case position cannot be placed
@@ -339,6 +349,16 @@ def buy():
 
                 else:
                     print('Order returned, saving order to file')
+
+                    # save buy to trades
+                    data = {
+                        "volume": volume[coin],
+                        "timestamp": time.time(),
+                        "action": "buy",
+                        "coin": coin,
+                        "lastPrice": last_price[coin]['price']
+                    }
+                    if MONGO: insert_trades(data, DATABASE_NAME)
 
                     
                     # Log trade
@@ -421,7 +441,7 @@ def sell_coins():
                     made_profit = True
                 data = {
                     "volume": coins_sold[coin]['volume'],
-                    "testMode": TEST_MODE,
+                    "timestamp": time.time(),
                     "action": "sell",
                     "madeProfit": made_profit,
                     "coin": coin,

--- a/Binance Detect Moonings.py
+++ b/Binance Detect Moonings.py
@@ -309,8 +309,8 @@ def buy():
                     "volume": volume[coin],
                     "timestamp": time.time(),
                     "action": "buy",
-                    "coin": coin,
-                    "lastPrice": last_price[coin]['price']
+                    "coin": str(coin),
+                    "buyPrice": float(last_price[coin]['price'])
                 }
                 if MONGO: insert_trades(data, DATABASE_NAME)
 
@@ -356,7 +356,7 @@ def buy():
                         "timestamp": time.time(),
                         "action": "buy",
                         "coin": coin,
-                        "lastPrice": last_price[coin]['price']
+                        "buyPrice": float(last_price[coin]['price'])
                     }
                     if MONGO: insert_trades(data, DATABASE_NAME)
 
@@ -447,7 +447,7 @@ def sell_coins():
                     "coin": coin,
                     "profit": profit,
                     "buyPrice": BuyPrice,
-                    "lastPrice": last_price[coin]['price']
+                    "sellPrice": LastPrice
                 }
                 if MONGO: insert_trades(data, DATABASE_NAME)
                     
@@ -492,10 +492,10 @@ def update_portfolio(orders, last_price, volume):
             'symbol': orders[coin][0]['symbol'],
             'orderid': orders[coin][0]['orderId'],
             'timestamp': orders[coin][0]['time'],
-            'bought_at': last_price[coin]['price'],
+            'buyPrice': float(last_price[coin]['price']),
             'volume': volume[coin],
-            'stop_loss': -STOP_LOSS,
-            'take_profit': TAKE_PROFIT,
+            'stopLoss': -STOP_LOSS,
+            'takeProfit': TAKE_PROFIT,
         }
         if MONGO: insert_portfolio(x, DATABASE_NAME)
         

--- a/Binance Detect Moonings.py
+++ b/Binance Detect Moonings.py
@@ -302,7 +302,7 @@ def buy():
             if TEST_MODE:
                 orders[coin] = [{
                     'symbol': coin,
-                    'orderId': time.time(),
+                    'orderId': fake_orderid(),
                     'time': datetime.now().timestamp()
                 }]
                 data = {
@@ -328,9 +328,6 @@ def buy():
                     type = 'MARKET',
                     quantity = volume[coin]
                 )
-
-
-                
 
             # error handling here in case position cannot be placed
             except Exception as e:
@@ -466,6 +463,7 @@ def sell_coins():
 def update_portfolio(orders, last_price, volume):
     '''add every coin bought to our portfolio for tracking/selling later'''
     if DEBUG: print(orders)
+    
     for coin in orders:
         x = {
             'symbol': orders[coin][0]['symbol'],
@@ -488,9 +486,14 @@ def update_portfolio(orders, last_price, volume):
     # it causes the json file to be malformed...
     # So this is the next best option...
     for coin in orders:
+        if TEST_MODE: 
+            order_id = fake_orderid()
+            if DEBUG: print(f"Running in test updating portfolio with fake orderid:{order_id}")
+        else:
+            order_id = orders[coin][0]['orderId']
         x = {
             'symbol': orders[coin][0]['symbol'],
-            'orderid': orders[coin][0]['orderId'],
+            'orderid': order_id,
             'timestamp': orders[coin][0]['time'],
             'buyPrice': float(last_price[coin]['price']),
             'volume': volume[coin],
@@ -503,11 +506,14 @@ def update_portfolio(orders, last_price, volume):
 def remove_from_portfolio(coins_sold):
     '''Remove coins sold due to SL or TP from portfolio'''
     for coin in coins_sold:
-        if DEBUG:
-            print(f'REMOVING FROM PORTFOLIO\n{coins_sold[coin]}')
+        
         if MONGO:
-            x = {'orderid': coins_sold[coin]['orderid']}
-            delete_portolio_item(x, DATABASE_NAME)
+            #x = {'orderid': coins_sold[coin]['orderid']}
+            x = {'symbol': coins_sold[coin]['symbol']}
+            delete_item = delete_portolio_item(x, DATABASE_NAME)
+            
+            
+
         coins_bought.pop(coin)
 
     with open(coins_bought_file_path, 'w') as file:

--- a/Binance Detect Moonings.py
+++ b/Binance Detect Moonings.py
@@ -673,11 +673,14 @@ if __name__ == '__main__':
     get_price()
 
     while True:
-        # Get information 
+        # Get current orders.
         orders, last_price, volume = buy()
-
-        update_portfolio(orders, last_price, volume)
+        if orders:
+             update_portfolio(orders, last_price, volume)
+    
+        # check to se if we're going to sell any coins
         coins_sold = sell_coins()
 
-        # remove from json
-        remove_from_portfolio(coins_sold)
+        if coins_sold:
+            # remove from json
+            remove_from_portfolio(coins_sold)

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,5 @@
 # These options apply to how the script will operate.
 script_options:
-  # Switch between testnet and mainnet
   # Setting this to False will use REAL funds, use at your own risk
   TEST_MODE: True
   LOG_TRADES: True
@@ -10,16 +9,13 @@ script_options:
   # Need to change TLD
   AMERICAN_USER: False
 
-
   # If you want to use mongodb for storage you can include this.
   # Please do not open tickets for mongo support
-
   USE_MONGO: False
 
 
 # These options apply to the trading methods the script executes
 trading_options:
- 
   # select what to pair the coins to and pull all coins paied with PAIR_WITH
   PAIR_WITH: USDT
 

--- a/config.yml
+++ b/config.yml
@@ -11,6 +11,11 @@ script_options:
   AMERICAN_USER: False
 
 
+  # If you want to use mongodb for storage you can include this.
+  # Please do not open tickets for mongo support
+  USE_MONGO: False
+
+
 # These options apply to the trading methods the script executes
 trading_options:
  

--- a/config.yml
+++ b/config.yml
@@ -13,6 +13,7 @@ script_options:
 
   # If you want to use mongodb for storage you can include this.
   # Please do not open tickets for mongo support
+
   USE_MONGO: False
 
 

--- a/helpers/db.py
+++ b/helpers/db.py
@@ -1,6 +1,11 @@
 from pymongo import MongoClient
+import random
 
 # SETUP
+def fake_orderid():
+    """returns a fake order id by hashing the current time"""
+    return random.randint(100000000,999999999)
+
 def my_client():
     return MongoClient('localhost', 27017)
 
@@ -39,7 +44,7 @@ def delete_portolio_item(data, database,table='portfolio'):
     db = client[database]
     table = db[table]
     x = table.delete_one(data)
-    return x
+    return x.raw_result
 
 def insert_portfolio(data,database,table='portfolio'):
     """inserts entry into porfolio collection

--- a/helpers/db.py
+++ b/helpers/db.py
@@ -1,0 +1,68 @@
+from pymongo import MongoClient
+
+# SETUP
+def my_client():
+    return MongoClient('localhost', 27017)
+
+def initialize_database(database, tables=['portfolio', 'trades']):
+    client = my_client()
+    db = client[database]
+    ids = []
+    print('MONGO: DBs and Collections are not created until data is stored in them...')
+    for table in tables:
+        print(f'MONGO: the {table} table does exist in {database} database, creating now...')
+        x = db[table]
+       
+
+
+def see_if_db_exists(default_dbs=['bvt','bvt-test']):
+    client = my_client()
+    dbnames = client.list_database_names()
+
+    for db in default_dbs:
+        if db not in dbnames:
+            print(f'MONGO: the {db} does not exist, creating now...')
+            initialize_database(db)
+
+
+
+# CRUD
+def insert_trades(data, database, table='trades'):
+    client = my_client()
+    db = client[database]
+    table = db[table]
+    x = table.insert_one(data)
+    return x
+
+def delete_portolio_item(data, database,table='portfolio'):
+    client = my_client()
+    db = client[database]
+    table = db[table]
+    x = table.delete_one(data)
+    return x
+
+def insert_portfolio(data,database,table='portfolio'):
+    """inserts entry into porfolio collection
+
+    Args:
+        client (class): dbclient
+        data (dict): 
+            example: {
+            
+                "symbol": "BTCUSDT",
+                "orderid": 0,
+                "timestamp": 1621952968.171957,
+                "bought_at": "37871.49000000",
+                "volume": 26.405087,
+                "stop_loss": -2.9,
+                "take_profit": 0.8
+            }
+    Returns:
+        [str]: db_row_id
+    """
+    client = my_client()
+    db = client[database]
+    table = db[table]
+    x = table.insert_one(data)
+    return x
+

--- a/helpers/handle_creds.py
+++ b/helpers/handle_creds.py
@@ -21,7 +21,6 @@ def test_api_key(client, BinanceAPIException):
     
     except BinanceAPIException as e:   
     
-      
         if e.code in  [-2015,-2014]:
             bad_key = "Your API key is not formatted correctly..."
             america = "If you are in america, you will have to update the config to set AMERICAN_USER: True"
@@ -35,8 +34,7 @@ def test_api_key(client, BinanceAPIException):
             msg = f"Timestamp for this request was 1000ms ahead of the server's time.\n  {issue}\n  {desc}"
         
         else:
-            msg = "Encountered an API Error code that was not caught nicely, please open issue...\n"
-            msg += e
+            msg = f"Encountered an API Error code that was not caught nicely, please open issue...\n: {e}"
 
         return False, msg
     

--- a/helpers/parameters.py
+++ b/helpers/parameters.py
@@ -20,4 +20,5 @@ def parse_args():
     x.add_argument('--config', '-c', help="Path to config.yml")
     x.add_argument('--creds', '-u', help="Path to creds file")
     x.add_argument('--notimeout', help="Dont use timeout in prod", action="store_true")
+    x.add_argument('--mongo', help="uses mongodb", action='store_true')
     return x.parse_args()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-binance==0.7.9
 colorama==0.4.4
 PyYAML==5.4.1
 tradingview-ta==3.2.3
+pymongo==3.11.4

--- a/utilities/cleanup_db.sh
+++ b/utilities/cleanup_db.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+echo "DELETING ALL"
+
+mongo <<EOF
+use bvt-test
+db.dropDatabase()
+use bvt
+db.dropDatabase()
+quit()
+exit

--- a/utilities/delete_prod_database.sh
+++ b/utilities/delete_prod_database.sh
@@ -1,0 +1,7 @@
+#! /bin/sh
+echo "DELETING BVT"
+mongo <<EOF
+use bvt
+db.dropDatabase()
+quit()
+exit

--- a/utilities/delete_test_database.sh
+++ b/utilities/delete_test_database.sh
@@ -1,0 +1,7 @@
+#! /bin/sh
+echo "DELETING BVT-TEST"
+mongo <<EOF
+use bvt-test
+db.dropDatabase()
+quit()
+exit

--- a/utilities/how_man_coins.py
+++ b/utilities/how_man_coins.py
@@ -1,0 +1,18 @@
+import json
+try:
+
+    with open('../coins_bought.json') as f:
+        prod_coins = json.load(f)
+    
+except Exception:
+    prod_coins = []
+    pass
+try:
+    with open('../test_coins_bought.json') as f:
+        test_coins = json.load(f)
+except Exception:
+    test_coins = []
+    pass
+print(f'prod_coins: {len(prod_coins)}')
+print(f'test_coins: {len(test_coins)}')
+print('\n\n')


### PR DESCRIPTION
## Lots to go over here.

Functionality can be set by either setting USE_MONGO: True, or using --mongo flag.

On first startup it will initiate two dbs and two tables (known as collections) in each db.


```
bvt (prod)
    > trades (trades.txt)
    > portfolio (coins_bought)
bvt-test(test)
    > trades (trades.txt)
    > portfolio (test_coins_bought)
```

Had to update the way test mode coins work, since to delete an item from a collection you need to set an ID of json key, I went with order ID. Manually set test orders to use the users local timestamp through `time.time()`.

Added a few bash scripts in utilities to cleanup either prod, test or both.

Verified working in test and prod, keep in mind this will work best if you delete coins_bought and test_coins_bought json files.

Tips to see if its working

 -  show me whats in my portfolio
      - `mongo <db_name_here> --eval 'db.portfolio.find().forEach(r=>print(JSON.stringify(r)))' --quiet`
 - show me all my trades
      - `mongo<db_name_here>  --eval 'db.trades.find().forEach(r=>print(JSON.stringify(r)))' --quiet`
