### PR TITLE
pass on coins added by external_signals() but not in historial_prices

### DIFF
--- a/Binance Detect Moonings.py
+++ b/Binance Detect Moonings.py
@@ -266,12 +266,14 @@ def convert_volume():
 
             if lot_size[coin] < 0:
                 lot_size[coin] = 0
-
         except:
             pass
 
         # calculate the volume in coin from QUANTITY in USDT (default)
-        volume[coin] = float(QUANTITY / float(last_price[coin]['price']))
+        try:
+            volume[coin] = float(QUANTITY / float(last_price[coin]['price']))
+        except:
+            pass
 
         # define the volume with the correct step size
         if coin not in lot_size:


### PR DESCRIPTION
### What are you addressing in this PR
  - [ ] Functionality 
  - [ ] Ease of use   
  - [X] Bug fix       

### How have you tested this PR

 - reproduced setup and run error from other users - simple try/except: pass added for fix

### In your own words, please share how this makes the codebase better.

Allows for previously added functionality to continue working in most cases and passes on instances where it would break the script

I believe this is happening because of external_signals() being used to add coins to the volitile_coins list, but not to the historical_prices list - which causes the key error when referencing the coin in last_price (since that's built from historical_prices).