### PR TITLE
Fixes #176. Bot buying more than MAX_COINS

### DIFF
--- a/Binance Detect Moonings.py
+++ b/Binance Detect Moonings.py
@@ -186,7 +186,8 @@ def wait_for_price():
     exnumber = 0
 
     for excoin in externals:
-        if excoin not in volatile_coins and excoin not in coins_bought and (len(coins_bought) + exnumber) < MAX_COINS:
+        if excoin not in volatile_coins and excoin not in coins_bought and \
+                (len(coins_bought) + exnumber + len(volatile_coins)) < MAX_COINS:
             volatile_coins[excoin] = 1
             exnumber +=1
             print(f'External signal received on {excoin}, calculating volume in {PAIR_WITH}')


### PR DESCRIPTION
### PRs that wont be accepted
  - typos
  - editing comments (unless critical)
  - edits in documentation (unless critical)

### What are you addressing in this PR
> Place X in the slot...
  - [ ] Functionality 
  - [ ] Ease of use   
  - [ X] Bug fix       

### How have you tested this PR

 - Validation must be ran in both `prod` and `test` (see TEST_MODE)
 - Original issue replicated below in test and prod.
    Testing condition - Already holding 3 coins. There need to be qualifying signals on both volatile & external list in same loop.
    Desired outcome: Bot should only buy 1 coin.
    Actual outcome: Bot buys 2 coins.
    ![here](https://user-images.githubusercontent.com/22363239/120842091-e3532300-c589-11eb-819a-cb8ba6e3458f.gif)
    
 - The bot was then tested with the fix in the same situation and it bought only 1 coin:
![fix_comments](https://user-images.githubusercontent.com/22363239/120842601-899f2880-c58a-11eb-95c4-f3324941f32a.gif)


### In your own words, please share how this makes the codebase better.
 - This will handle instances where the bot is buying more than the MAX_COINS set in the config file