### PR TITLE
Sell positions after some time

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -51,6 +51,9 @@ trading_options:
   # define in % when to take profit on a profitable coin.
   TAKE_PROFIT: .8
 
+  # Sell coin after a fixed duration in minutes. Value 0 means this fuctinality is disables.
+  SELL_AFTER_DURATION: 0
+  
   # Use custom tickers.txt list for filtering pairs.
   CUSTOM_LIST: True
    


### PR DESCRIPTION
### PRs that wont be accepted
  - typos
  - editing comments (unless critical)
  - edits in documentation (unless critical)

### What are you addressing in this PR
> Place X in the slot...
  - [X] Functionality 
  - [ ] Ease of use   
  - [ ] Bug fix       

### How have you tested this PR

 - Validation must be ran in both `prod` and `test` (see TEST_MODE)
 - Enter a description here. Empty descriptions will be closed.

This has been tested in both test and prod. 
I haven't observed any issue so far.

### In your own words, please share how this makes the codebase better.

Added a new preference SELL_AFTER_DURATION to sell coins after a fixed duration in minutes.
Value 0 means this functionality is disabled.
For example, SELL_AFTER_DURATION: 15.0 means, that any coin will be sold if it's still held after 15 minutes from the time is was bought.