### PR TITLE
Fixing Trailing Stop Loss to correctly update the stop_loss value

### DIFF
--- a/Binance Detect Moonings.py
+++ b/Binance Detect Moonings.py
@@ -374,8 +374,8 @@ def sell_coins():
         if LastPrice > TP and USE_TRAILING_STOP_LOSS:
 
             # increasing TP by TRAILING_TAKE_PROFIT (essentially next time to readjust SL)
-            coins_bought[coin]['take_profit'] = PriceChange + TRAILING_TAKE_PROFIT
             coins_bought[coin]['stop_loss'] = coins_bought[coin]['take_profit'] - TRAILING_STOP_LOSS
+            coins_bought[coin]['take_profit'] = PriceChange + TRAILING_TAKE_PROFIT
             if DEBUG: print(f"{coin} TP reached, adjusting TP {coins_bought[coin]['take_profit']:.2f}  and SL {coins_bought[coin]['stop_loss']:.2f} accordingly to lock-in profit")
             continue
 


### PR DESCRIPTION
### What are you addressing in this PR
> Place X in the slot...
  - [ ] Functionality 
  - [ ] Ease of use   
  - [X] Bug fix       

### How have you tested this PR

Corrected behaviour has been verified, see below

### In your own words, please share how this makes the codebase better.

when USE_TRAILING_STOP_LOSS is enabled and the take_profit value for a coin is reached the new stop_loss value should be set to just below the existing take_profit (ie `take_profit - TRAILING_STOP_LOSS`). 

Due to the order of the operations this was being incorrectly set to `take_profit + TRAILING_TAKE_PROFT - TRAILING_STOP_LOSS`

This PR simply switches the order of the operations to update take_profit and stop_loss to prevent the bug.

### Test output

```
$ python3 Binance\ Detect\ Moonings.py --debug
[2021-06-15 14:14:35] loaded config below
{
    "script_options": {
        "TEST_MODE": false,
<snip>
    "trading_options": {
<snip>
        "TAKE_PROFIT": 0.5,
        "USE_TRAILING_STOP_LOSS": true,
        "TRAILING_STOP_LOSS": 0.05,
        "TRAILING_TAKE_PROFIT": 0.75,
        "TRADING_FEE": 0.075,
<snip>
[2021-06-15 14:45:28] PERLUSDT TP reached, adjusting TP 1.49  and SL 0.45 accordingly to lock-in profit
```

For comparison, existing **incorrect** behaviour with same params:

```
[2021-06-15 14:02:54] ATAUSDT TP reached, adjusting TP 1.36  and SL 1.31 accordingly to lock-in profit
[2021-06-15 14:03:04] TP or SL reached, selling 15 ATAUSDT - 0.95917 - 0.96757 : 0.73% Est:$0.11
```
